### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md + verified end-to-end)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Cellar is a Linux-only Go control plane for isolated sandboxes. The repo builds four
+Go binaries (`cellard`, `cellar`, `cellar-gateway`, `cellar-agent`), a TypeScript SDK
+(`sdk/node`), and a Fumadocs docs site (`docs/`). Standard commands live in the
+`Makefile` (`make build`, `make test`) and in the `scripts` of `sdk/node/package.json`
+and `docs/package.json` — refer to those rather than duplicating them here.
+
+### Toolchain (already present in the VM snapshot)
+- Go 1.26.x is selected automatically via `GOTOOLCHAIN=auto` (declared in `go.mod`).
+- Node 22 and `bun` (installed at `~/.bun/bin`, added to `PATH` via `~/.bashrc`) — the
+  Node SDK and docs site use `bun`, not npm/pnpm.
+- Docker Engine + gVisor `runsc` are installed. `runsc` is registered in
+  `/etc/docker/daemon.json` and is required for the sandbox lifecycle.
+
+### Running the services (non-obvious caveats)
+- **Docker is not managed by systemd here.** Start it manually before any sandbox work:
+  `sudo dockerd` (leave it running; it logs to your terminal). `make`/`go test` do not
+  need it, but `cellar sandbox …` does.
+- **gVisor needs two runtime args in this nested VM.** `/etc/docker/daemon.json`
+  registers `runsc` with `--host-uds=create` (so `cellar-agent` can bind its control
+  socket) **and** `--ignore-cgroups`. Without `--ignore-cgroups`, `runsc` containers
+  fail at startup with `configuring cgroup: write .../cgroup.subtree_control: operation
+  not supported`. After editing that file, reload with `sudo kill -HUP $(pgrep -x dockerd)`.
+- **Run the daemon/CLI/gateway as root** (`sudo`). The control socket is
+  `/var/run/cellar/cellar.sock` (owned `root:root`, mode 0660) and `cellard` needs the
+  Docker socket. `cellard` resolves the `cellar-agent` binary next to its own executable,
+  so run the freshly built `bin/cellard` (which sits beside `bin/cellar-agent`).
+- Typical bring-up: `sudo bin/cellard` → `sudo bin/cellar init --advertise-addr
+  127.0.0.1:17946` → `sudo bin/cellar status` (expect `is_leader: true`) →
+  `sudo bin/cellar api-key create --name demo` → optionally `sudo bin/cellar-gateway
+  --listen 127.0.0.1:8080 --data-dir /var/lib/cellar` (health at `/healthz`, `/readyz`).
+  Sandboxes really boot under gVisor — `sandbox exec … -- uname -a` reports a
+  `*-gvisor` kernel.
+
+### Tests
+- `make test` (`go test ./...`) passes except one **pre-existing** failure:
+  `internal/daemon` `TestSandboxAPIClientViaGatewayFailover`. It fails because the JSON
+  API encodes `int64` fields (e.g. `updatedAtUnixNano`) as strings (standard protojson
+  behavior) while that test's client decodes into `int64`. It is unrelated to
+  environment setup — do not treat it as an env regression.
+- SDK checks (from `sdk/node`): `bun run test`, `bun run typecheck`, `bun run build`.
+  Note `bun run lint` runs `oxlint --fix` and will modify files; use `bunx oxlint`
+  (no `--fix`) for a read-only check.
+- Docs (from `docs/`): `bun run types:check`, `bun run build`, `bun run dev` (serves on
+  `:3000`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies a full development environment for Cellar in Cursor Cloud, and adds an `AGENTS.md` with durable, non-obvious run/setup notes for future agents. No product code was modified.

The environment now builds, tests, and runs every component of the monorepo:
- Go control plane: `cellard`, `cellar`, `cellar-gateway`, `cellar-agent`
- TypeScript SDK: `sdk/node`
- Docs site: `docs/` (Next.js / Fumadocs)

## What was installed (captured in the VM snapshot)
- `bun` (for `sdk/node` and `docs`)
- Docker Engine + gVisor `runsc` (registered in `/etc/docker/daemon.json` with `--host-uds=create` and `--ignore-cgroups` — the latter is required for `runsc` to start in this nested VM)
- Go 1.26.x is auto-selected via `GOTOOLCHAIN=auto` from `go.mod`; Node 22 was already present

The startup update script only refreshes dependencies (`go mod download`, `bun install` in `sdk/node` and `docs`).

## Verification

| Component | Lint | Test | Build | Run |
| --- | --- | --- | --- | --- |
| Go control plane | `go vet` via build | `go test ./...` (1 pre-existing failure, see below) | `make build` (4 binaries) | `cellard` + `cellar init/status/api-key`, `cellar-gateway` (`/healthz`,`/readyz`) |
| `sdk/node` | `oxlint` (clean) | `bun run test` (13 passed) | `bun run build` | n/a (client lib) |
| `docs` | — | `bun run types:check` | `bun run build` | `bun run dev` (:3000) |

**End-to-end sandbox lifecycle** was exercised both via the CLI and the public HTTP gateway. Sandboxes really boot under gVisor (`uname` reports a `*-gvisor` kernel), and `exec` runs commands inside them:

```
$ curl -H 'Authorization: Bearer cellar_***' .../v1/sandboxes/<id>/exec -d '{"command":["sh","-c","echo hello-via-gateway-http-api; uname -r"]}'
{"stdout":"hello-via-gateway-http-api\n4.19.0-gvisor\n","stderr":"","exitCode":0}
```

### Pre-existing test failure (not caused by this change)
`internal/daemon` `TestSandboxAPIClientViaGatewayFailover` fails because the JSON API encodes `int64` fields (e.g. `updatedAtUnixNano`) as strings (standard protojson behavior) while that test's client decodes into `int64`. It reproduces on the untouched base commit and is unrelated to environment setup, so it was left as-is per the "do not modify existing code" guidance.

## Changes
- Add `AGENTS.md` documenting the toolchain, the manual `dockerd` start, the gVisor `runsc` args gotcha, running the daemon/CLI/gateway as root, and the known pre-existing test failure.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b29df394-495d-4f74-bb64-eda44d5b9d98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b29df394-495d-4f74-bb64-eda44d5b9d98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

