### PR TITLE
Fix essential-services YAML sandbox create

### DIFF
--- a/cmd/cellar/sandbox_file_test.go
+++ b/cmd/cellar/sandbox_file_test.go
@@ -128,6 +128,22 @@ func TestLoadSandboxCreateFileExamples(t *testing.T) {
 	}
 }
 
+func TestLoadExampleEssentialServicesImpliesBlockAll(t *testing.T) {
+	req, err := loadSandboxCreateFile("../../examples/sandbox-essential-services.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Spec.Image != "alpine" {
+		t.Fatalf("image=%q want alpine", req.Spec.Image)
+	}
+	if !req.Spec.Network.EssentialServices {
+		t.Fatal("expected essential_services")
+	}
+	if req.Spec.Network.BlockAll == nil || !*req.Spec.Network.BlockAll {
+		t.Fatal("expected block_all implied by essential_services alone")
+	}
+}
+
 func TestParseSandboxCreateFileDomainAllowList(t *testing.T) {
 	const yamlDoc = `
 id: demo-domains

--- a/examples/sandbox-essential-services.yaml
+++ b/examples/sandbox-essential-services.yaml
@@ -1,6 +1,6 @@
 # Curated package/git/AI domains only (implies block_all).
 # Usage: cellar sandbox create -f examples/sandbox-essential-services.yaml
 id: demo-essentials
-image: curlimages/curl
+image: alpine
 network:
   essential_services: true

--- a/internal/egress/listen_test.go
+++ b/internal/egress/listen_test.go
@@ -1,0 +1,97 @@
+package egress
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestListenDNSRetriesUntilAddrReady(t *testing.T) {
+	t.Cleanup(func() {
+		listenUDP = net.ListenUDP
+		listenTCP = net.Listen
+		dnsBindAttempts = 20
+		dnsBindRetry = 50 * time.Millisecond
+	})
+	dnsBindAttempts = 5
+	dnsBindRetry = time.Millisecond
+
+	var udpCalls atomic.Int32
+	listenUDP = func(network string, laddr *net.UDPAddr) (*net.UDPConn, error) {
+		n := udpCalls.Add(1)
+		if n < 3 {
+			return nil, syscall.EADDRNOTAVAIL
+		}
+		return net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	}
+	listenTCP = func(network, address string) (net.Listener, error) {
+		return net.Listen("tcp", "127.0.0.1:0")
+	}
+
+	udp, tcp, err := listenDNS("172.30.0.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = udp.Close()
+		_ = tcp.Close()
+	})
+	if got := udpCalls.Load(); got != 3 {
+		t.Fatalf("udp calls=%d want 3", got)
+	}
+}
+
+func TestCatchAllSpecsAvoidsInvertedMultiport(t *testing.T) {
+	specs := catchAllSpecs("172.30.0.2", "172.30.0.3")
+	if len(specs) != 5 {
+		t.Fatalf("specs=%d want 5 (3 except + to-leg + routed)", len(specs))
+	}
+	for i, spec := range specs {
+		joined := strings.Join(spec, " ")
+		if strings.Contains(joined, "multiport") {
+			t.Fatalf("spec[%d] uses multiport (nftables cannot invert it): %s", i, joined)
+		}
+		if strings.Contains(joined, "!") && strings.Contains(joined, "dport") {
+			t.Fatalf("spec[%d] inverts a dport match: %s", i, joined)
+		}
+	}
+	if got := strings.Join(specs[0], " "); !strings.Contains(got, "--dport 53") || !strings.Contains(got, "-j RETURN") {
+		t.Fatalf("spec[0]=%s want RETURN for :53", got)
+	}
+	if got := strings.Join(specs[3], " "); !strings.Contains(got, "REDIRECT") || !strings.Contains(got, "--to-ports") {
+		t.Fatalf("spec[3]=%s want catch-all REDIRECT", got)
+	}
+}
+
+func TestListenDNSGivesUp(t *testing.T) {
+	t.Cleanup(func() {
+		listenUDP = net.ListenUDP
+		listenTCP = net.Listen
+		dnsBindAttempts = 20
+		dnsBindRetry = 50 * time.Millisecond
+	})
+	dnsBindAttempts = 3
+	dnsBindRetry = time.Millisecond
+
+	listenUDP = func(network string, laddr *net.UDPAddr) (*net.UDPConn, error) {
+		return nil, syscall.EADDRNOTAVAIL
+	}
+	listenTCP = func(network, address string) (net.Listener, error) {
+		t.Fatal("tcp listen should not be called when udp fails")
+		return nil, errors.New("unused")
+	}
+
+	udp, tcp, err := listenDNS("172.30.0.2")
+	if err == nil {
+		_ = udp.Close()
+		_ = tcp.Close()
+		t.Fatal("expected error")
+	}
+	if udp != nil || tcp != nil {
+		t.Fatalf("expected nil listeners, got udp=%v tcp=%v", udp, tcp)
+	}
+}

--- a/internal/egress/server.go
+++ b/internal/egress/server.go
@@ -212,18 +212,9 @@ func (s *Server) RegisterSandbox(_ context.Context, req *cellarv1.RegisterSandbo
 	}
 	sbIP := SandboxIP(subnet)
 
-	udpAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(req.GetGatewayIp(), "53"))
+	udpConn, tcpLis, err := listenDNS(req.GetGatewayIp())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "dns udp addr: %v", err)
-	}
-	udpConn, err := net.ListenUDP("udp", udpAddr)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "listen dns udp %s: %v", req.GetGatewayIp(), err)
-	}
-	tcpLis, err := net.Listen("tcp", net.JoinHostPort(req.GetGatewayIp(), "53"))
-	if err != nil {
-		_ = udpConn.Close()
-		return nil, status.Errorf(codes.Internal, "listen dns tcp %s: %v", req.GetGatewayIp(), err)
+		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 
 	if err := addCatchAllRedirect(req.GetGatewayIp(), sbIP.String()); err != nil {
@@ -679,6 +670,50 @@ func (s *Server) handleDNS(sess *session, pkt []byte, reply func([]byte)) {
 	reply(out)
 }
 
+// dnsBindAttempts / dnsBindRetry are vars so tests can shrink the window.
+var (
+	dnsBindAttempts = 20
+	dnsBindRetry    = 50 * time.Millisecond
+)
+
+// listenUDP / listenTCP are net defaults, overridden in tests.
+var (
+	listenUDP = net.ListenUDP
+	listenTCP = net.Listen
+)
+
+// listenDNS binds UDP/TCP :53 on host. Retries because Docker may not have
+// assigned the gateway .2 address yet right after NetworkConnect.
+func listenDNS(host string) (*net.UDPConn, net.Listener, error) {
+	addr := net.JoinHostPort(host, "53")
+	var last error
+	for attempt := 0; attempt < dnsBindAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(dnsBindRetry)
+		}
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("dns udp addr: %w", err)
+		}
+		udpConn, err := listenUDP("udp", udpAddr)
+		if err != nil {
+			last = fmt.Errorf("listen dns udp %s: %w", host, err)
+			continue
+		}
+		tcpLis, err := listenTCP("tcp", addr)
+		if err != nil {
+			_ = udpConn.Close()
+			last = fmt.Errorf("listen dns tcp %s: %w", host, err)
+			continue
+		}
+		return udpConn, tcpLis, nil
+	}
+	if last == nil {
+		return nil, nil, fmt.Errorf("listen dns %s: exhausted retries", host)
+	}
+	return nil, nil, last
+}
+
 func addCatchAllRedirect(gatewayIP, sandboxIP string) error {
 	specs := catchAllSpecs(gatewayIP, sandboxIP)
 	var applied [][]string
@@ -709,11 +744,14 @@ func deleteCatchAllRedirect(gatewayIP, sandboxIP string) error {
 
 func catchAllSpecs(gatewayIP, sandboxIP string) [][]string {
 	port := strconv.Itoa(catchAllPort)
-	// DNS-bait path: traffic destined to this gateway leg on non-80/443/53
-	// ports (domain allowlist with explicit ports).
+	// Dedicated listeners own :53 / :80 / :443 on the gateway leg. Skip
+	// those ports with RETURN instead of `multiport ! --dports` — nftables
+	// rejects inverted multiport ("multiport.0 does not support invert").
+	except := func(dport string) []string {
+		return []string{"PREROUTING", "-d", gatewayIP, "-p", "tcp", "--dport", dport, "-j", "RETURN"}
+	}
 	toLeg := []string{
 		"PREROUTING", "-d", gatewayIP, "-p", "tcp",
-		"-m", "multiport", "!", "--dports", "53,80,443",
 		"-j", "REDIRECT", "--to-ports", port,
 	}
 	// Routed raw-IP path: sandbox default route via .2 preserves the original
@@ -723,7 +761,7 @@ func catchAllSpecs(gatewayIP, sandboxIP string) [][]string {
 		"PREROUTING", "-s", sandboxIP, "!", "-d", gatewayIP, "-p", "tcp",
 		"-j", "REDIRECT", "--to-ports", port,
 	}
-	return [][]string{toLeg, routed}
+	return [][]string{except("53"), except("80"), except("443"), toLeg, routed}
 }
 
 func runIPTables(action string, spec []string) error {

--- a/internal/runtime/docker_integration_test.go
+++ b/internal/runtime/docker_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 
+	"github.com/prodioslabs/cellar/internal/egress"
 	"github.com/prodioslabs/cellar/internal/sandbox"
 )
 
@@ -210,6 +211,91 @@ func TestReconcileReapsDeadContainer(t *testing.T) {
 		t.Fatalf("phase: got %s want running", phase)
 	}
 	phases = rep.phases()
+	if phases[len(phases)-1] != sandbox.PhaseRunning {
+		t.Fatalf("last reported phase: got %v", phases)
+	}
+}
+
+func TestReconcileEssentialServicesCreate(t *testing.T) {
+	if os.Getenv("CELLAR_INTEGRATION") != "1" {
+		t.Skip("set CELLAR_INTEGRATION=1 to run Docker integration tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	driver, err := NewDriver()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer driver.Close()
+
+	if _, _, err := driver.cli.ImageInspectWithRaw(ctx, "cellar/egress-gateway"); err != nil {
+		t.Skip("cellar/egress-gateway image not loaded (make egress-gateway-image)")
+	}
+
+	agentBinary, err := filepath.Abs("../../bin/cellar-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := driver.pullIfMissing(ctx, "alpine"); err != nil {
+		t.Fatal(err)
+	}
+
+	const sandboxID = "integration-essentials"
+	_ = driver.Remove(ctx, "cellar-sb-"+sandboxID)
+	_ = driver.RemoveSandboxNetwork(ctx, sandboxID)
+
+	dataDir := t.TempDir()
+	ipam, err := egress.NewAllocator(dataDir, "172.31.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := egress.NewPool(driver.Client(), egress.PoolConfig{
+		DataDir: dataDir,
+		Image:   "cellar/egress-gateway",
+	})
+	if err := pool.EnsureReady(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { pool.Close(context.Background()) })
+
+	sb := &sandbox.Sandbox{
+		ID:                   sandboxID,
+		DesiredState:         sandbox.DesiredRunning,
+		AssignmentGeneration: 1,
+		Spec: sandbox.Spec{
+			Image: "alpine",
+			Network: sandbox.NetworkPolicy{
+				Mode:              sandbox.NetworkBlockAll,
+				EssentialServices: true,
+				DNS:               sandbox.DNSPolicy{Mode: sandbox.DNSNone},
+			},
+		},
+	}
+	src := &memAssignments{sb: []*sandbox.Sandbox{sb}}
+	rep := &memReporter{}
+	agent := NewAgent("node-test", driver, pool, ipam, src, rep, dataDir, agentBinary)
+
+	if err := agent.reconcile(ctx); err != nil {
+		t.Fatal(err)
+	}
+	cid := agent.LocalContainerID(sandboxID)
+	if cid == "" {
+		t.Fatalf("expected container, phases=%v", rep.phases())
+	}
+	t.Cleanup(func() {
+		_ = driver.Remove(context.Background(), cid)
+		_ = driver.RemoveSandboxNetwork(context.Background(), sandboxID)
+	})
+	phase, _, err := driver.InspectPhase(ctx, cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if phase != sandbox.PhaseRunning {
+		t.Fatalf("phase: got %s want running (status=%v)", phase, rep.phases())
+	}
+	phases := rep.phases()
 	if phases[len(phases)-1] != sandbox.PhaseRunning {
 		t.Fatalf("last reported phase: got %v", phases)
 	}

--- a/internal/sandbox/limits.go
+++ b/internal/sandbox/limits.go
@@ -47,7 +47,7 @@ func ResolveNetworkPolicy(np NetworkPolicy, networkAllowList, domainAllowList st
 	// everything except curated hosts.
 	essentialsAlone := out.EssentialServices && allowCIDRs == "" && allowDomains == "" && !hasBlock && !hasAllowAll &&
 		(np.Mode == "" || np.Mode == NetworkNone) &&
-		len(np.Rules) == 0 && np.DNS.Mode == "" && len(np.DNS.Names) == 0
+		len(np.Rules) == 0 && (np.DNS.Mode == "" || np.DNS.Mode == DNSNone) && len(np.DNS.Names) == 0
 
 	if limitCount > 1 {
 		return NetworkPolicy{}, fmt.Errorf("network_allow_list, domain_allow_list, block_all, and allow_all are mutually exclusive; set at most one")

--- a/internal/sandbox/limits_test.go
+++ b/internal/sandbox/limits_test.go
@@ -116,7 +116,7 @@ func TestResolveMutualExclusion(t *testing.T) {
 		t.Fatalf("expected mutually exclusive, got %v", err)
 	}
 	_, err = sandbox.ResolveNetworkPolicy(sandbox.NetworkPolicy{
-		Mode: sandbox.NetworkAllowlist,
+		Mode:  sandbox.NetworkAllowlist,
 		Rules: []sandbox.NetworkRule{{Hosts: []string{"x.com"}}},
 	}, "10.0.0.0/8", "", nil, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "cannot combine") {
@@ -218,6 +218,22 @@ func TestResolveEssentialServicesAloneImpliesBlockAll(t *testing.T) {
 	}
 	if np.Mode != sandbox.NetworkBlockAll {
 		t.Fatalf("mode=%q want blockall", np.Mode)
+	}
+
+	// Round-tripped specs send dns.mode=none with mode none; still upgrade.
+	np, err = sandbox.ResolveNetworkPolicyFromProto(&cellarv1.NetworkPolicy{
+		Mode:              "none",
+		EssentialServices: true,
+		Dns:               &cellarv1.DNSPolicy{Mode: "none"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if np.Mode != sandbox.NetworkBlockAll {
+		t.Fatalf("mode=%q want blockall (dns none)", np.Mode)
+	}
+	if !np.EssentialServices {
+		t.Fatal("expected essential_services after dns none round-trip")
 	}
 
 	// Structured allowlist + essentials must not be rewritten to blockall.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
YAML `essential_services: true` implies `blockall`, so create writes Raft state and the runtime agent must build egress topology. That step was reporting `phase=failed`.

**Root cause:** `RegisterSandbox` installed a catch-all NAT rule with inverted multiport (`-m multiport ! --dports 53,80,443`). nftables rejects that (`multiport.0 does not support invert`), so registration failed and the sandbox never reached `running`.

**Fix:**
- Replace inverted multiport with RETURN exceptions for TCP 53/80/443 and a plain REDIRECT for everything else
- Retry DNS bind after `NetworkConnect` (gateway `.2` may not be assignable immediately)
- Treat `dns.mode=none` as unset when resolving essentials-alone so round-tripped specs still become `blockall`
- Switch [examples/sandbox-essential-services.yaml](examples/sandbox-essential-services.yaml) to `alpine` (same as block-all)

Verified locally: `cellar sandbox create -f examples/sandbox-essential-services.yaml` now reaches `phase=running`, as do isolated and block-all examples.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06764-dcae-71c4-a583-de42eb4af60d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06764-dcae-71c4-a583-de42eb4af60d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

