### PR TITLE
docs: homepage install hero, CLI animation, and SDK showcase

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -13,6 +13,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "tailwind-merge": "^3.6.0",
+        "three": "^0.160.0",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -20,6 +21,7 @@
         "@types/node": "^25.8.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.160.0",
         "oxfmt": "^0.61.0",
         "oxlint": "^1.76.0",
         "postcss": "^8.5.14",
@@ -391,7 +393,13 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.160.0", "", { "dependencies": { "@types/stats.js": "*", "@types/webxr": "*", "fflate": "~0.6.10", "meshoptimizer": "~0.18.1" } }, "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
@@ -480,6 +488,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.6.11", "", {}, "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg=="],
 
     "framer-motion": ["framer-motion@12.43.0", "", { "dependencies": { "motion-dom": "^12.43.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g=="],
 
@@ -596,6 +606,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -772,6 +784,8 @@
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "three": ["three@0.160.1", "", {}, "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,8 @@
     "next": "16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "three": "^0.160.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
@@ -27,6 +28,7 @@
     "@types/node": "^25.8.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.160.0",
     "oxfmt": "^0.61.0",
     "oxlint": "^1.76.0",
     "postcss": "^8.5.14",

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -1,36 +1,13 @@
-import Image from 'next/image'
-import Link from 'next/link'
+import { CliShowcase } from '@/components/home/cli-terminal'
+import { Hero } from '@/components/home/hero'
+import { SdkShowcase } from '@/components/home/sdk-showcase'
 
 export default function HomePage() {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center px-6 py-16 text-center">
-      <Image
-        src="/cellar-logo.png"
-        alt="Cellar — isometric C of slate-blue cubes with a single orange cube in the center"
-        width={160}
-        height={160}
-        priority
-        className="mb-8"
-      />
-      <h1 className="mb-4 text-4xl font-bold tracking-tight">Cellar</h1>
-      <p className="mb-8 max-w-2xl text-lg text-fd-muted-foreground">
-        A container orchestrator control plane for isolated sandboxes — cluster identity over mTLS
-        gRPC, Raft-replicated CA, Docker + hardened runc, and userspace egress policy.
-      </p>
-      <div className="flex flex-wrap items-center justify-center gap-3">
-        <Link
-          href="/docs"
-          className="rounded-full bg-fd-primary px-5 py-2.5 text-sm font-medium text-fd-primary-foreground transition-opacity hover:opacity-90"
-        >
-          Read the docs
-        </Link>
-        <Link
-          href="/docs/quick-start"
-          className="rounded-full border px-5 py-2.5 text-sm font-medium transition-colors hover:bg-fd-accent"
-        >
-          Quick start
-        </Link>
-      </div>
+    <div className="flex flex-1 flex-col">
+      <Hero />
+      <CliShowcase />
+      <SdkShowcase />
     </div>
   )
 }

--- a/docs/src/components/home/cli-terminal.tsx
+++ b/docs/src/components/home/cli-terminal.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+type Step = {
+  command: string
+  output: string[]
+}
+
+const SCRIPT: Step[] = [
+  {
+    command: 'cellar init --advertise-addr 127.0.0.1:17946',
+    output: [
+      'Cluster initialized: 7f3a2c91-4b18-4e2d-9a6c-1d8e0f2b3c4d (node 1a2b3c4d)',
+    ],
+  },
+  {
+    command: 'cellar sandbox create --id demo --runtime node-26',
+    output: ['sandbox demo created (node=1a2b3c4d phase=pending)'],
+  },
+  {
+    command: `cellar sandbox exec demo -- node -e 'console.log("hello from cellar")'`,
+    output: ['hello from cellar'],
+  },
+]
+
+const TYPE_MS = 28
+const AFTER_COMMAND_MS = 380
+const AFTER_OUTPUT_MS = 900
+const LOOP_HOLD_MS = 2200
+
+function fullTranscript() {
+  return SCRIPT.flatMap((step, i) => [
+    { kind: 'command' as const, text: step.command, key: `c-${i}` },
+    ...step.output.map((line, j) => ({
+      kind: 'output' as const,
+      text: line,
+      key: `o-${i}-${j}`,
+    })),
+  ])
+}
+
+export function CliTerminal() {
+  const [reducedMotion, setReducedMotion] = useState(false)
+  const [stepIndex, setStepIndex] = useState(0)
+  const [typed, setTyped] = useState(0)
+  const [showOutput, setShowOutput] = useState(false)
+  const pausedRef = useRef(false)
+  const mountedRef = useRef(false)
+
+  useEffect(() => {
+    mountedRef.current = true
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const apply = () => setReducedMotion(mq.matches)
+    apply()
+    mq.addEventListener('change', apply)
+    return () => {
+      mountedRef.current = false
+      mq.removeEventListener('change', apply)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (reducedMotion) return
+
+    const step = SCRIPT[stepIndex]
+    let timer: number
+
+    const schedule = (fn: () => void, ms: number) => {
+      timer = window.setTimeout(() => {
+        if (!mountedRef.current) return
+        if (pausedRef.current) {
+          schedule(fn, 120)
+          return
+        }
+        fn()
+      }, ms)
+    }
+
+    if (!showOutput) {
+      if (typed < step.command.length) {
+        schedule(() => setTyped((n) => n + 1), TYPE_MS)
+      } else {
+        schedule(() => setShowOutput(true), AFTER_COMMAND_MS)
+      }
+    } else if (stepIndex < SCRIPT.length - 1) {
+      schedule(() => {
+        setStepIndex((i) => i + 1)
+        setTyped(0)
+        setShowOutput(false)
+      }, AFTER_OUTPUT_MS)
+    } else {
+      schedule(() => {
+        setStepIndex(0)
+        setTyped(0)
+        setShowOutput(false)
+      }, LOOP_HOLD_MS)
+    }
+
+    return () => window.clearTimeout(timer)
+  }, [reducedMotion, stepIndex, typed, showOutput])
+
+  const lines = reducedMotion
+    ? fullTranscript()
+    : [
+        ...SCRIPT.slice(0, stepIndex).flatMap((step, i) => [
+          { kind: 'command' as const, text: step.command, key: `c-${i}` },
+          ...step.output.map((line, j) => ({
+            kind: 'output' as const,
+            text: line,
+            key: `o-${i}-${j}`,
+          })),
+        ]),
+        {
+          kind: 'typing' as const,
+          text: SCRIPT[stepIndex].command.slice(0, typed),
+          key: `t-${stepIndex}`,
+        },
+        ...(showOutput
+          ? SCRIPT[stepIndex].output.map((line, j) => ({
+              kind: 'output' as const,
+              text: line,
+              key: `o-${stepIndex}-${j}`,
+            }))
+          : []),
+      ]
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950 text-left shadow-lg"
+      onMouseEnter={() => {
+        pausedRef.current = true
+      }}
+      onMouseLeave={() => {
+        pausedRef.current = false
+      }}
+      role="img"
+      aria-label="Animated demo of initializing Cellar and creating a sandbox from the CLI"
+    >
+      <div className="flex items-center gap-2 border-b border-neutral-800 px-4 py-2.5">
+        <span className="size-2.5 rounded-full bg-red-400/80" aria-hidden />
+        <span className="size-2.5 rounded-full bg-amber-400/80" aria-hidden />
+        <span className="size-2.5 rounded-full bg-emerald-400/80" aria-hidden />
+        <span className="ml-2 font-mono text-xs text-neutral-400">cellar</span>
+      </div>
+      <pre className="min-h-[17rem] overflow-x-auto p-4 font-mono text-[13px] leading-relaxed text-neutral-100 sm:min-h-[18rem] sm:text-sm">
+        {lines.map((line) =>
+          line.kind === 'output' ? (
+            <div key={line.key} className="text-neutral-400">
+              {line.text || '\u00a0'}
+            </div>
+          ) : (
+            <div key={line.key} className="whitespace-pre">
+              <span className="text-emerald-400">$</span>{' '}
+              <span>{line.text}</span>
+              {line.kind === 'typing' && !reducedMotion ? (
+                <span className="ml-px inline-block w-1.5 animate-pulse bg-emerald-300 align-[-2px]">
+                  &nbsp;
+                </span>
+              ) : null}
+            </div>
+          ),
+        )}
+      </pre>
+    </div>
+  )
+}
+
+export function CliShowcase() {
+  return (
+    <section className="border-t border-fd-border px-6 py-16 sm:py-20">
+      <div className="mx-auto grid w-full max-w-5xl items-center gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:gap-14">
+        <div>
+          <p className="mb-2 text-sm font-medium text-fd-muted-foreground">CLI</p>
+          <h2 className="mb-4 text-2xl font-bold tracking-tight sm:text-3xl">
+            From zero to a running sandbox
+          </h2>
+          <p className="mb-6 text-fd-muted-foreground">
+            Initialize a cluster, create a hardened container with a language runtime, and exec
+            inside it. Three commands — no YAML required.
+          </p>
+          <ol className="space-y-3 text-sm">
+            <li className="flex gap-3">
+              <span className="mt-0.5 font-mono text-fd-muted-foreground">1</span>
+              <span>
+                <code className="font-mono text-[13px]">cellar init</code> stands up the control
+                plane
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-0.5 font-mono text-fd-muted-foreground">2</span>
+              <span>
+                <code className="font-mono text-[13px]">sandbox create</code> schedules a container
+                with <code className="font-mono text-[13px]">--runtime node-26</code>
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span className="mt-0.5 font-mono text-fd-muted-foreground">3</span>
+              <span>
+                <code className="font-mono text-[13px]">sandbox exec</code> runs your command in
+                isolation
+              </span>
+            </li>
+          </ol>
+        </div>
+        <CliTerminal />
+      </div>
+    </section>
+  )
+}

--- a/docs/src/components/home/cli-terminal.tsx
+++ b/docs/src/components/home/cli-terminal.tsx
@@ -10,9 +10,7 @@ type Step = {
 const SCRIPT: Step[] = [
   {
     command: 'cellar init --advertise-addr 127.0.0.1:17946',
-    output: [
-      'Cluster initialized: 7f3a2c91-4b18-4e2d-9a6c-1d8e0f2b3c4d (node 1a2b3c4d)',
-    ],
+    output: ['Cluster initialized: 7f3a2c91 (node 1a2b3c4d)'],
   },
   {
     command: 'cellar sandbox create --id demo --runtime node-26',
@@ -143,14 +141,14 @@ export function CliTerminal() {
         <span className="size-2.5 rounded-full bg-emerald-400/80" aria-hidden />
         <span className="ml-2 font-mono text-xs text-neutral-400">cellar</span>
       </div>
-      <pre className="min-h-[17rem] overflow-x-auto p-4 font-mono text-[13px] leading-relaxed text-neutral-100 sm:min-h-[18rem] sm:text-sm">
+      <pre className="min-h-[17rem] overflow-x-hidden p-4 font-mono text-[13px] leading-relaxed break-words whitespace-pre-wrap text-neutral-100 sm:min-h-[18rem] sm:text-sm">
         {lines.map((line) =>
           line.kind === 'output' ? (
             <div key={line.key} className="text-neutral-400">
               {line.text || '\u00a0'}
             </div>
           ) : (
-            <div key={line.key} className="whitespace-pre">
+            <div key={line.key}>
               <span className="text-emerald-400">$</span>{' '}
               <span>{line.text}</span>
               {line.kind === 'typing' && !reducedMotion ? (

--- a/docs/src/components/home/hero.tsx
+++ b/docs/src/components/home/hero.tsx
@@ -1,18 +1,11 @@
-import Image from 'next/image'
 import Link from 'next/link'
 import { InstallCommand } from './install-command'
+import { MetallicCube } from './metallic-cube'
 
 export function Hero() {
   return (
-    <section className="flex flex-col items-center px-6 py-16 text-center sm:py-24">
-      <Image
-        src="/cellar-logo.png"
-        alt="Cellar — isometric C of slate-blue cubes with a single orange cube in the center"
-        width={128}
-        height={128}
-        priority
-        className="mb-8"
-      />
+    <section className="flex flex-col items-center px-6 pb-16 pt-6 text-center sm:pb-24 sm:pt-8">
+      <MetallicCube />
       <h1 className="mb-4 max-w-3xl text-4xl font-bold tracking-tight sm:text-5xl">
         Isolated sandboxes in one command
       </h1>

--- a/docs/src/components/home/hero.tsx
+++ b/docs/src/components/home/hero.tsx
@@ -1,0 +1,40 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { InstallCommand } from './install-command'
+
+export function Hero() {
+  return (
+    <section className="flex flex-col items-center px-6 py-16 text-center sm:py-24">
+      <Image
+        src="/cellar-logo.png"
+        alt="Cellar — isometric C of slate-blue cubes with a single orange cube in the center"
+        width={128}
+        height={128}
+        priority
+        className="mb-8"
+      />
+      <h1 className="mb-4 max-w-3xl text-4xl font-bold tracking-tight sm:text-5xl">
+        Isolated sandboxes in one command
+      </h1>
+      <p className="mb-8 max-w-2xl text-lg text-fd-muted-foreground">
+        Install Cellar, create a hardened container, and run untrusted code with userspace egress
+        policy.
+      </p>
+      <InstallCommand className="mb-8" />
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Link
+          href="/docs/quick-start"
+          className="rounded-full bg-fd-primary px-5 py-2.5 text-sm font-medium text-fd-primary-foreground transition-opacity hover:opacity-90"
+        >
+          Quick start
+        </Link>
+        <Link
+          href="/docs"
+          className="rounded-full border px-5 py-2.5 text-sm font-medium transition-colors hover:bg-fd-accent"
+        >
+          Read the docs
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/docs/src/components/home/install-command.tsx
+++ b/docs/src/components/home/install-command.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+import { cn } from '@/lib/cn'
+
+export const INSTALL_COMMAND = 'curl -fsSL https://cellar.prodioslabs.in/install.sh | sh'
+
+export function InstallCommand({
+  command = INSTALL_COMMAND,
+  className,
+}: {
+  command?: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1600)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex w-full max-w-2xl items-center gap-2 rounded-xl border border-fd-border bg-fd-card px-3 py-2 shadow-sm sm:px-4 sm:py-2.5',
+        className,
+      )}
+    >
+      <span className="shrink-0 font-mono text-sm text-fd-muted-foreground select-none" aria-hidden>
+        $
+      </span>
+      <code className="min-w-0 flex-1 truncate text-left font-mono text-[13px] text-fd-foreground sm:text-sm">
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+        aria-label={copied ? 'Copied install command' : 'Copy install command'}
+      >
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+        <span className="hidden sm:inline">{copied ? 'Copied' : 'Copy'}</span>
+      </button>
+    </div>
+  )
+}

--- a/docs/src/components/home/metallic-cube.tsx
+++ b/docs/src/components/home/metallic-cube.tsx
@@ -1,0 +1,333 @@
+'use client'
+
+import Image from 'next/image'
+import { useEffect, useRef, useState } from 'react'
+import * as THREE from 'three'
+
+const P = 'P'
+const S = 'S'
+const E = '.'
+
+type Cell = typeof P | typeof S | typeof E
+
+const GRID: Cell[][][] = [
+  [
+    [P, P, P],
+    [P, P, P],
+    [P, P, P],
+  ],
+  [
+    [P, P, P],
+    [P, S, E],
+    [P, E, E],
+  ],
+  [
+    [P, P, P],
+    [P, E, E],
+    [P, E, E],
+  ],
+]
+
+const COLORS = {
+  P: 0xd9dde3,
+  S: 0xf5a013,
+} as const
+
+function makeEnvironment() {
+  const env = new THREE.Scene()
+  env.background = new THREE.Color(0x9aa3af)
+  const panel = (w: number, h: number, col: number, x: number, y: number, z: number, ry = 0, rx = 0) => {
+    const m = new THREE.Mesh(
+      new THREE.PlaneGeometry(w, h),
+      new THREE.MeshBasicMaterial({ color: col, side: THREE.DoubleSide }),
+    )
+    m.position.set(x, y, z)
+    m.rotation.set(rx, ry, 0)
+    env.add(m)
+  }
+  panel(14, 4, 0xffffff, 0, 6, 0, 0, Math.PI / 2)
+  panel(6, 10, 0xe9edf2, -9, 0, 0, Math.PI / 2)
+  panel(6, 10, 0x3b5678, 9, 0, 0, Math.PI / 2)
+  panel(10, 6, 0xffe1b0, 0, 1, -9)
+  panel(14, 14, 0x22293a, 0, -6, 0, 0, Math.PI / 2)
+  return env
+}
+
+function roundedBox(size: number, radius: number, segments = 6) {
+  const g = new THREE.BoxGeometry(size, size, size, segments, segments, segments)
+  const pos = g.attributes.position
+  const nor = g.attributes.normal
+  const inner = size / 2 - radius
+  const v = new THREE.Vector3()
+  const c = new THREE.Vector3()
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i)
+    c.set(
+      THREE.MathUtils.clamp(v.x, -inner, inner),
+      THREE.MathUtils.clamp(v.y, -inner, inner),
+      THREE.MathUtils.clamp(v.z, -inner, inner),
+    )
+    v.sub(c).normalize()
+    nor.setXYZ(i, v.x, v.y, v.z)
+    v.multiplyScalar(radius).add(c)
+    pos.setXYZ(i, v.x, v.y, v.z)
+  }
+  return g
+}
+
+function addSpot(
+  scene: THREE.Scene,
+  color: number,
+  intensity: number,
+  x: number,
+  y: number,
+  z: number,
+  shadow = false,
+) {
+  const l = new THREE.SpotLight(color, intensity, 0, Math.PI / 6, 0.45, 1.6)
+  l.position.set(x, y, z)
+  l.target.position.set(0, -0.3, 0)
+  if (shadow) {
+    l.castShadow = true
+    l.shadow.mapSize.set(1024, 1024)
+    l.shadow.bias = -0.0008
+  }
+  scene.add(l, l.target)
+  return l
+}
+
+const ditherVertex = /* glsl */ `
+  varying vec2 vUv;
+  void main(){
+    vUv = uv;
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+  }
+`
+
+const ditherFragment = /* glsl */ `
+  precision highp float;
+  uniform sampler2D tDiffuse;
+  uniform vec2  resolution;
+  uniform float pixelSize, levels, strength;
+  varying vec2 vUv;
+
+  float bayer8(vec2 p){
+    int x = int(mod(p.x, 8.0)), y = int(mod(p.y, 8.0));
+    int m[64];
+    m[ 0]= 0; m[ 1]=32; m[ 2]= 8; m[ 3]=40; m[ 4]= 2; m[ 5]=34; m[ 6]=10; m[ 7]=42;
+    m[ 8]=48; m[ 9]=16; m[10]=56; m[11]=24; m[12]=50; m[13]=18; m[14]=58; m[15]=26;
+    m[16]=12; m[17]=44; m[18]= 4; m[19]=36; m[20]=14; m[21]=46; m[22]= 6; m[23]=38;
+    m[24]=60; m[25]=28; m[26]=52; m[27]=20; m[28]=62; m[29]=30; m[30]=54; m[31]=22;
+    m[32]= 3; m[33]=35; m[34]=11; m[35]=43; m[36]= 1; m[37]=33; m[38]= 9; m[39]=41;
+    m[40]=51; m[41]=19; m[42]=59; m[43]=27; m[44]=49; m[45]=17; m[46]=57; m[47]=25;
+    m[48]=15; m[49]=47; m[50]= 7; m[51]=39; m[52]=13; m[53]=45; m[54]= 5; m[55]=37;
+    m[56]=63; m[57]=31; m[58]=55; m[59]=23; m[60]=61; m[61]=29; m[62]=53; m[63]=21;
+    int i = y * 8 + x;
+    for (int k = 0; k < 64; k++) { if (k == i) return (float(m[k]) + 0.5) / 64.0; }
+    return 0.5;
+  }
+
+  void main(){
+    vec2 px   = floor(vUv * resolution / pixelSize) * pixelSize;
+    vec2 uv   = (px + pixelSize * 0.5) / resolution;
+    vec4 src  = texture2D(tDiffuse, uv);
+    if (src.a < 0.02) {
+      gl_FragColor = vec4(0.0);
+      return;
+    }
+    vec3 col  = src.rgb;
+    float t   = (bayer8(px / pixelSize) - 0.5) * strength;
+    vec3 q    = floor(col * levels + t + 0.5) / levels;
+    q = clamp(q, 0.0, 1.0);
+    gl_FragColor = vec4(q * src.a, src.a);
+  }
+`
+
+function startScene(canvas: HTMLCanvasElement) {
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: false,
+    alpha: true,
+    premultipliedAlpha: true,
+  })
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+  renderer.setClearColor(0x000000, 0)
+  renderer.shadowMap.enabled = true
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap
+  renderer.toneMapping = THREE.ACESFilmicToneMapping
+  renderer.toneMappingExposure = 1.05
+
+  const scene = new THREE.Scene()
+  scene.background = null
+
+  const camera = new THREE.PerspectiveCamera(28, 1, 0.1, 100)
+  camera.position.set(7, 6.2, 9)
+  camera.lookAt(0, 0, 0)
+
+  const pmrem = new THREE.PMREMGenerator(renderer)
+  const envRt = pmrem.fromScene(makeEnvironment(), 0.04)
+  scene.environment = envRt.texture
+
+  const CELL = 1.0
+  const GAP = 0.03
+  const RADIUS = 0.09
+  const cubeGroup = new THREE.Group()
+  scene.add(cubeGroup)
+
+  const geo = roundedBox(CELL - GAP, RADIUS)
+  const mats = {
+    P: new THREE.MeshStandardMaterial({
+      color: COLORS.P,
+      metalness: 1.0,
+      roughness: 0.18,
+      envMapIntensity: 1.3,
+    }),
+    S: new THREE.MeshStandardMaterial({
+      color: COLORS.S,
+      metalness: 0.85,
+      roughness: 0.28,
+      envMapIntensity: 1.4,
+    }),
+  }
+
+  GRID.forEach((layer, y) =>
+    layer.forEach((row, z) =>
+      row.forEach((cell, x) => {
+        if (cell === E) return
+        const m = new THREE.Mesh(geo, mats[cell])
+        m.position.set((x - 1) * CELL, (y - 1) * CELL, (z - 1) * CELL)
+        m.castShadow = m.receiveShadow = true
+        cubeGroup.add(m)
+      }),
+    ),
+  )
+
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(40, 40), new THREE.ShadowMaterial({ opacity: 0.18 }))
+  ground.rotation.x = -Math.PI / 2
+  ground.position.y = -2.3
+  ground.receiveShadow = true
+  scene.add(ground)
+
+  scene.add(new THREE.AmbientLight(0xffffff, 0.25))
+  const keyLight = addSpot(scene, 0xffffff, 140, 6, 9, 5, true)
+  addSpot(scene, 0x9fc4ff, 120, -7, 6, -6)
+  addSpot(scene, 0xffd9a3, 60, -5, 3, 7)
+  addSpot(scene, 0xffffff, 70, 0, 11, 0)
+
+  const rt = new THREE.WebGLRenderTarget(1, 1, { type: THREE.HalfFloatType })
+  const ditherMat = new THREE.ShaderMaterial({
+    uniforms: {
+      tDiffuse: { value: rt.texture },
+      resolution: { value: new THREE.Vector2() },
+      pixelSize: { value: 2.0 },
+      levels: { value: 7.0 },
+      strength: { value: 1.0 },
+    },
+    vertexShader: ditherVertex,
+    fragmentShader: ditherFragment,
+    depthTest: false,
+    depthWrite: false,
+    transparent: true,
+    premultipliedAlpha: true,
+  })
+
+  const postScene = new THREE.Scene()
+  const postCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+  const postQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), ditherMat)
+  postScene.add(postQuad)
+
+  const resize = () => {
+    const w = canvas.clientWidth
+    const h = canvas.clientHeight
+    if (w < 1 || h < 1) return
+    renderer.setSize(w, h, false)
+    camera.aspect = w / h
+    camera.updateProjectionMatrix()
+    const dpr = renderer.getPixelRatio()
+    rt.setSize(Math.max(1, Math.floor(w * dpr)), Math.max(1, Math.floor(h * dpr)))
+    ditherMat.uniforms.resolution.value.set(w * dpr, h * dpr)
+  }
+
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  const clock = new THREE.Clock()
+  let raf = 0
+  let running = true
+
+  const frame = () => {
+    if (!running) return
+    const t = clock.getElapsedTime()
+    if (!reduceMotion) {
+      cubeGroup.rotation.y = t * 0.45
+      cubeGroup.rotation.x = Math.sin(t * 0.6) * 0.18
+      cubeGroup.position.y = Math.sin(t * 0.9) * 0.08
+      keyLight.position.x = 6 * Math.cos(t * 0.3)
+      keyLight.position.z = 5 * Math.sin(t * 0.3) + 2
+    } else {
+      cubeGroup.rotation.set(0.35, 0.8, 0)
+    }
+
+    renderer.setRenderTarget(rt)
+    renderer.setClearColor(0x000000, 0)
+    renderer.render(scene, camera)
+    renderer.setRenderTarget(null)
+    renderer.setClearColor(0x000000, 0)
+    renderer.render(postScene, postCamera)
+
+    raf = requestAnimationFrame(frame)
+  }
+
+  const observer = new ResizeObserver(resize)
+  observer.observe(canvas)
+  resize()
+  frame()
+
+  return () => {
+    running = false
+    cancelAnimationFrame(raf)
+    observer.disconnect()
+    geo.dispose()
+    mats.P.dispose()
+    mats.S.dispose()
+    ground.geometry.dispose()
+    ;(ground.material as THREE.Material).dispose()
+    postQuad.geometry.dispose()
+    ditherMat.dispose()
+    rt.dispose()
+    envRt.dispose()
+    pmrem.dispose()
+    renderer.dispose()
+  }
+}
+
+export function MetallicCube() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    try {
+      return startScene(canvas)
+    } catch {
+      setFailed(true)
+    }
+  }, [])
+
+  if (failed) {
+    return (
+      <div className="relative mx-auto mb-8 flex h-32 w-full max-w-4xl items-center justify-center">
+        <Image src="/cellar-logo.png" alt="" width={128} height={128} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative mx-auto h-[min(56vh,32rem)] w-full max-w-4xl sm:h-[min(62vh,38rem)]">
+      <canvas
+        ref={canvasRef}
+        aria-hidden="true"
+        className="absolute inset-0 block size-full pointer-events-none"
+      />
+    </div>
+  )
+}

--- a/docs/src/components/home/sdk-showcase.tsx
+++ b/docs/src/components/home/sdk-showcase.tsx
@@ -1,0 +1,94 @@
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock'
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
+import Link from 'next/link'
+
+const TS_INSTALL = 'npm install @cellar/node'
+
+const TS_CODE = `import { Client } from '@cellar/node'
+
+const sb = await Client.fromEnv().create({
+  spec: { runtime: 'node-26' },
+})
+await sb.waitUntilReady()
+const { stdout } = await sb.exec(['node', '-e', 'console.log("hello")'])
+console.log(stdout.toString())
+await sb.remove()
+`
+
+const GO_INSTALL = 'go get github.com/prodioslabs/cellar/sdk/go'
+
+const GO_CODE = `c, _ := client.NewFromEnv()
+sb, _ := c.Create(ctx, &client.SandboxCreateRequest{
+  Spec: &client.SandboxSpec{Runtime: "node-26"},
+})
+_ = sb.WaitUntilReady(ctx, client.WaitUntilReadyOptions{})
+res, _ := sb.Exec(ctx, []string{"node", "-e", \`console.log("hello")\`})
+`
+
+export function SdkShowcase() {
+  return (
+    <section className="border-t border-fd-border px-6 py-16 sm:py-20">
+      <div className="mx-auto w-full max-w-5xl">
+        <p className="mb-2 text-sm font-medium text-fd-muted-foreground">SDKs</p>
+        <h2 className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl">
+          Same API in TypeScript and Go
+        </h2>
+        <p className="mb-8 max-w-2xl text-fd-muted-foreground">
+          Create a sandbox, wait until it is running, exec, then tear it down. Both clients talk to{' '}
+          <code className="font-mono text-[13px]">cellar-gateway</code> with an API key.
+        </p>
+        <Tabs items={['TypeScript', 'Go']} className="rounded-xl bg-fd-card p-1">
+          <Tab value="TypeScript">
+            <SdkPanel
+              install={TS_INSTALL}
+              lang="ts"
+              code={TS_CODE}
+              title="create-sandbox.ts"
+              href="/docs/sdk/node"
+              label="TypeScript SDK docs"
+            />
+          </Tab>
+          <Tab value="Go">
+            <SdkPanel
+              install={GO_INSTALL}
+              lang="go"
+              code={GO_CODE}
+              title="create_sandbox.go"
+              href="/docs/sdk/go"
+              label="Go SDK docs"
+            />
+          </Tab>
+        </Tabs>
+      </div>
+    </section>
+  )
+}
+
+function SdkPanel({
+  install,
+  lang,
+  code,
+  title,
+  href,
+  label,
+}: {
+  install: string
+  lang: string
+  code: string
+  title: string
+  href: string
+  label: string
+}) {
+  return (
+    <div className="space-y-3">
+      <DynamicCodeBlock lang="bash" code={install} codeblock={{ title: 'Install' }} />
+      <DynamicCodeBlock lang={lang} code={code} codeblock={{ title }} />
+      <Link
+        href={href}
+        className="inline-flex text-sm font-medium text-fd-primary underline-offset-4 hover:underline"
+      >
+        {label} →
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace the docs homepage with a three-section landing page that shows how to install Cellar, create a sandbox from the CLI, and use the TypeScript and Go SDKs.

## Changes

- **Hero** — dithered metallic C-cube (Three.js, transparent canvas so the Fumadocs light/dark page background shows through), copyable `curl … | sh` installer, Quick start / Docs CTAs
- **CLI** — looping typewriter terminal: `init` → `sandbox create --runtime node-26` → `sandbox exec`
- **SDKs** — TypeScript (`@cellar/node`) and Go (`sdk/go`) tabs with highlighted create/exec examples

The Fumadocs navbar, theme tokens, and docs MDX pages are unchanged. The CLI and cube animations honor `prefers-reduced-motion`. Long terminal lines wrap so commands stay readable.

Verified in the browser: cube rotation in light and dark (transparent canvas), copy button, full CLI loop, TypeScript/Go tabs, and a mobile viewport.

## Walkthrough

[homepage-cube-walkthrough.mp4](https://cursor.com/agents/bc-01a0681b-1a2c-7633-ba43-803fe7d7abb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-cube-walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0681b-1a2c-7633-ba43-803fe7d7abb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0681b-1a2c-7633-ba43-803fe7d7abb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

